### PR TITLE
DEC-459 fix TypeError in setup.py causes build to fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def verify_dependency(executable_name, min_version=None, suffix=None):
                 sys.exit("Could not determine version of %s" % executable_name)
 
             if min_version:
-                version_nums = str.split(XYZ, '.')
+                version_nums = XYZ.split('.')
                 for idx, val in enumerate(str.split(min_version, '.')):
                     if idx >= len(version_nums) or int(val) > int(version_nums[idx]):
                         if exit:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def verify_dependency(executable_name, min_version=None, suffix=None):
 
             if min_version:
                 version_nums = XYZ.split('.')
-                for idx, val in enumerate(str.split(min_version, '.')):
+                for idx, val in enumerate(min_version.split('.')):
                     if idx >= len(version_nums) or int(val) > int(version_nums[idx]):
                         if exit:
                             sys.exit("You must upgrade %s to %s or higher" % (executable_name, min_version))


### PR DESCRIPTION
TypeError: descriptor 'split' requires a 'str' object but received a 'unicode'